### PR TITLE
config: Remove deprecated flag

### DIFF
--- a/cc/config/global.go
+++ b/cc/config/global.go
@@ -347,7 +347,6 @@ func init() {
 		[]string{
 			// Default to zero initialization.
 			"-ftrivial-auto-var-init=zero",
-			"-enable-trivial-auto-var-init-zero-knowing-it-will-be-removed-from-clang",
 		}...)
 	exportedVars.ExportStringList("CommonGlobalCflags", bazelCommonGlobalCflags)
 
@@ -358,14 +357,14 @@ func init() {
 		// Automatically initialize any uninitialized stack variables.
 		// Prefer zero-init if multiple options are set.
 		if ctx.Config().IsEnvTrue("AUTO_ZERO_INITIALIZE") {
-			flags = append(flags, "-ftrivial-auto-var-init=zero -enable-trivial-auto-var-init-zero-knowing-it-will-be-removed-from-clang")
+			flags = append(flags, "-ftrivial-auto-var-init=zero")
 		} else if ctx.Config().IsEnvTrue("AUTO_PATTERN_INITIALIZE") {
 			flags = append(flags, "-ftrivial-auto-var-init=pattern")
 		} else if ctx.Config().IsEnvTrue("AUTO_UNINITIALIZE") {
 			flags = append(flags, "-ftrivial-auto-var-init=uninitialized")
 		} else {
 			// Default to zero initialization.
-			flags = append(flags, "-ftrivial-auto-var-init=zero -enable-trivial-auto-var-init-zero-knowing-it-will-be-removed-from-clang")
+			flags = append(flags, "-ftrivial-auto-var-init=zero")
 		}
 
 		// Workaround for ccache with clang.


### PR DESCRIPTION
- -enable-trivial-auto-var-init-zero-knowing-it-will-be-removed-from-clang has been deprecated in commit [1], hence let's drop it to fix a build error.

[1]: https://github.com/llvm/llvm-project/commit/aef03c9b3bed5cef5a1940774b80128aefcb4095

Signed-off-by: Cyber Knight <cyberknight755@gmail.com>