### PR TITLE
Add exynos-m4 support

### DIFF
--- a/android/arch_list.go
+++ b/android/arch_list.go
@@ -93,6 +93,7 @@ var cpuVariants = map[ArchType][]string{
 		"kryo385",
 		"exynos-m1",
 		"exynos-m2",
+		"exynos-m4",
 	},
 	Arm64: {
 		"cortex-a510",
@@ -107,6 +108,7 @@ var cpuVariants = map[ArchType][]string{
 		"kryo785",
 		"exynos-m1",
 		"exynos-m2",
+		"exynos-m4",
 		"oryon",
 	},
 	X86:    {},

--- a/cc/config/arm64_device.go
+++ b/cc/config/arm64_device.go
@@ -100,6 +100,9 @@ var (
 		"exynos-m2": []string{
 			"-mcpu=exynos-m2",
 		},
+		"exynos-m4": []string{
+			"-mcpu=exynos-m4",
+                },
 	}
 )
 
@@ -134,6 +137,7 @@ func init() {
 	pctx.StaticVariable("Arm64Kryo785Cflags", strings.Join(arm64CpuVariantCflags["kryo785"], " "))
 	pctx.StaticVariable("Arm64ExynosM1Cflags", strings.Join(arm64CpuVariantCflags["exynos-m1"], " "))
 	pctx.StaticVariable("Arm64ExynosM2Cflags", strings.Join(arm64CpuVariantCflags["exynos-m2"], " "))
+	pctx.StaticVariable("Arm64ExynosM4Cflags", strings.Join(arm64CpuVariantCflags["exynos-m4"], " "))
 	pctx.StaticVariable("Arm64CortexA510Cflags", strings.Join(arm64CpuVariantCflags["cortex-a510"], " "))
 	pctx.StaticVariable("Arm64CortexA76Cflags", strings.Join(arm64CpuVariantCflags["cortex-a76"], " "))
 	pctx.StaticVariable("Arm64Kryo385Cflags", strings.Join(arm64CpuVariantCflags["kryo385"], " "))
@@ -155,6 +159,7 @@ var (
 		"kryo785":    "${config.Arm64Kryo785Cflags}",
 		"exynos-m1":   "${config.Arm64ExynosM1Cflags}",
 		"exynos-m2":   "${config.Arm64ExynosM2Cflags}",
+		"exynos-m4":   "${config.Arm64ExynosM4Cflags}",
 	}
 
 	arm64CpuVariantLdflags = map[string]string{
@@ -164,6 +169,8 @@ var (
 		"kryo":       "${config.Arm64FixCortexA53Ldflags}",
 		"exynos-m1":  "${config.Arm64FixCortexA53Ldflags}",
 		"exynos-m2":  "${config.Arm64FixCortexA53Ldflags}",
+		"exynos-m4":  "${config.Arm64FixCortexA53Ldflags}",
+
 	}
 )
 

--- a/cc/config/arm_device.go
+++ b/cc/config/arm_device.go
@@ -248,6 +248,7 @@ var (
 		"kryo385":        "${config.ArmKryo385Cflags}",
 		"exynos-m1":      "${config.ArmCortexA53Cflags}",
 		"exynos-m2":      "${config.ArmCortexA53Cflags}",
+		"exynos-m4":      "${config.ArmCortexA53Cflags}",
 	}
 )
 


### PR DESCRIPTION
* m4 is not a55 due to lack of instructions, neither is it a53 due to some extra instructions from a55